### PR TITLE
Expose the admin email as an environment variable, rather than hardcoding it

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,6 @@ Required environment variables:
 | SKM_CLIENT_ID             | xxx.apps.googleusercontent.com  | Google oidc client id                                                          |
 | SKM_CLIENT_SECRET         | xxxxxxxx                        | Google oidc client secret                                                      |
 | SKM_CALLBACK_URL          | https://app/callback            | Callback URI where user will be redirected after successful Google interaction |
-| SKM_AWS_ACCESS_KEY_ID     | AKIAXXXXXXXXXXXXXXXX            | AWS access key                                                                 |
-| SKM_AWS_SECRET_ACCESS_KEY | xxxxxxxxxxxxxxxxxxxxx           | AWS secret access key                                                          |
 | SKM_AWS_BUCKET            | bucket-name                     | AWS s3 bucket name                                                             |
 | SKM_SA_KEY_LOC            | /etc/skm/sa-key.json            | Location on disk where Google service account key is (json format)             |
 | SKM_GROUPS                | "group@gsuite-domain.com"       | comma seperated list of groups that will be synced to s3                       |

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Required environment variables:
 | SKM_AWS_BUCKET            | bucket-name                     | AWS s3 bucket name                                                             |
 | SKM_SA_KEY_LOC            | /etc/skm/sa-key.json            | Location on disk where Google service account key is (json format)             |
 | SKM_GROUPS                | "group@gsuite-domain.com"       | comma seperated list of groups that will be synced to s3                       |
+| SKM_ADMIN_EMAIL           | "admin-user@gsuite-domain.com"  | A G-Suite admin user                       |
 
 ### client
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Required environment variables:
 | SKM_GROUPS                | "group@gsuite-domain.com"       | comma seperated list of groups that will be synced to s3                       |
 | SKM_ADMIN_EMAIL           | "admin-user@gsuite-domain.com"  | A G-Suite admin user                       |
 
+You will also need to configure the appropriate AWS credentials for your environment, as detailed [on this page](https://docs.aws.amazon.com/sdk-for-go/v1/developer-guide/configuring-sdk.html#specifying-credentials).
+
 ### client
 
 Use https://github.com/utilitywarehouse/ssh-key-agent on your host to populate `authorized_keys`

--- a/main.go
+++ b/main.go
@@ -47,6 +47,7 @@ var (
 	awsBucket          = os.Getenv("SKM_AWS_BUCKET")
 	saKeyLoc           = os.Getenv("SKM_SA_KEY_LOC")
 	groups             = os.Getenv("SKM_GROUPS")
+	adminEmail         = os.Getenv("SKM_ADMIN_EMAIL")
 
 	scopes = []string{"https://www.googleapis.com/auth/admin.directory.user", "https://www.googleapis.com/auth/admin.directory.group.member.readonly"}
 
@@ -125,7 +126,7 @@ func authenticatedClient() (client *http.Client) {
 		log.Fatal(err)
 	}
 	conf, err := google.JWTConfigFromJSON(data, scopes...)
-	conf.Subject = "mdonat@utilitywarehouse.co.uk"
+	conf.Subject = adminEmail
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"sync"
 
@@ -42,12 +43,12 @@ var (
 	googleClientID     = os.Getenv("SKM_CLIENT_ID")
 	googleClientSecret = os.Getenv("SKM_CLIENT_SECRET")
 	googleCallbackURL  = os.Getenv("SKM_CALLBACK_URL")
+	googleAdminEmail   = os.Getenv("SKM_ADMIN_EMAIL")
 	awsAccessKey       = os.Getenv("SKM_AWS_ACCESS_KEY_ID")
 	awsSecretKey       = os.Getenv("SKM_AWS_SECRET_ACCESS_KEY")
 	awsBucket          = os.Getenv("SKM_AWS_BUCKET")
 	saKeyLoc           = os.Getenv("SKM_SA_KEY_LOC")
 	groups             = os.Getenv("SKM_GROUPS")
-	adminEmail         = os.Getenv("SKM_ADMIN_EMAIL")
 
 	scopes = []string{"https://www.googleapis.com/auth/admin.directory.user", "https://www.googleapis.com/auth/admin.directory.group.member.readonly"}
 
@@ -62,6 +63,47 @@ type tokenResponse struct {
 	AccessToken  string `json:"access_token"`
 	RefreshToken string `json:"refresh_token"`
 	IDToken      string `json:"id_token"`
+}
+
+// Validate arguments
+func validate() {
+	var err error
+
+	// Client ID
+	clientIDRegex := regexp.MustCompile("^.*apps.googleusercontent.com$")
+	if !clientIDRegex.MatchString(googleClientID) {
+		log.Fatalln(googleClientID + " is not a valid client ID")
+	}
+
+	// Client secret
+	if googleClientSecret == "" {
+		log.Fatalln("client secret must not be empty")
+	}
+
+	// Callback URL
+	u, err := url.ParseRequestURI(googleCallbackURL)
+	if err != nil || (u.Host == "" || u.Scheme == "") {
+		log.Fatalln(googleCallbackURL + " is not a valid URI")
+	}
+
+	// Admin email string
+	emailRegex := regexp.MustCompile("^[a-zA-Z0-9.!#$%&'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$")
+	if len(googleAdminEmail) > 254 || !emailRegex.MatchString(googleAdminEmail) {
+		log.Fatalln(googleAdminEmail + " is not a valid email address")
+	}
+
+	// AWS S3 bucket
+	if awsBucket == "" {
+		log.Fatalln("SKM_AWS_BUCKET must not be empty")
+	}
+
+	// SA key location
+	_, err = os.Stat(saKeyLoc)
+	if os.IsNotExist(err) {
+		log.Fatalln(saKeyLoc + " does not exist")
+	} else if err != nil {
+		log.Fatalln("can't stat " + saKeyLoc)
+	}
 }
 
 // Get the id_token and refresh_token from google
@@ -126,7 +168,7 @@ func authenticatedClient() (client *http.Client) {
 		log.Fatal(err)
 	}
 	conf, err := google.JWTConfigFromJSON(data, scopes...)
-	conf.Subject = adminEmail
+	conf.Subject = googleAdminEmail
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -240,8 +282,14 @@ func authMapPage(am *authMap) http.Handler {
 }
 
 func main() {
+	validate()
+
 	adminClient := authenticatedClient()
 	groups := strings.Split(groups, ",")
+	if len(groups) == 0 {
+		log.Fatalln("SKM_GROUPS can't be empty")
+	}
+
 	am := &authMap{client: adminClient, inputGroups: groups}
 	go am.sync()
 

--- a/main.go
+++ b/main.go
@@ -44,8 +44,6 @@ var (
 	googleClientSecret = os.Getenv("SKM_CLIENT_SECRET")
 	googleCallbackURL  = os.Getenv("SKM_CALLBACK_URL")
 	googleAdminEmail   = os.Getenv("SKM_ADMIN_EMAIL")
-	awsAccessKey       = os.Getenv("SKM_AWS_ACCESS_KEY_ID")
-	awsSecretKey       = os.Getenv("SKM_AWS_SECRET_ACCESS_KEY")
 	awsBucket          = os.Getenv("SKM_AWS_BUCKET")
 	saKeyLoc           = os.Getenv("SKM_SA_KEY_LOC")
 	groups             = os.Getenv("SKM_GROUPS")

--- a/sync.go
+++ b/sync.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 )
@@ -123,10 +122,7 @@ func (am *authMap) groupsFromGoogle() ([]group, error) {
 func (am *authMap) postToAWS() {
 	body, _ := json.Marshal(am)
 
-	sess, err := session.NewSession(&aws.Config{
-		Region:      aws.String("eu-west-1"),
-		Credentials: credentials.NewStaticCredentials(awsAccessKey, awsSecretKey, ""),
-	})
+	sess, err := session.NewSession(&aws.Config{})
 
 	if err != nil {
 		log.Printf("aws - Failed to create a session %v", err)


### PR DESCRIPTION
Makes this app usable outside of our specific org. Also lays the groundwork for using a different email account as our admin.