### PR TITLE
Avoid pushing an empty cache to S3 by checking the status code of the…

### DIFF
--- a/sync.go
+++ b/sync.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -91,6 +92,13 @@ func (am *authMap) groupsFromGoogle() ([]group, error) {
 			resp.Body.Close()
 		}()
 
+		if resp.StatusCode != 200 {
+			var body bytes.Buffer
+			body.ReadFrom(resp.Body)
+
+			return nil, errors.New(body.String())
+		}
+
 		memList, err := decodeMemberList(resp.Body)
 		if err != nil {
 			return nil, err
@@ -111,6 +119,13 @@ func (am *authMap) groupsFromGoogle() ([]group, error) {
 				io.Copy(ioutil.Discard, resp.Body)
 				resp.Body.Close()
 			}()
+
+			if resp.StatusCode != 200 {
+				var body bytes.Buffer
+				body.ReadFrom(resp.Body)
+
+				return nil, errors.New(body.String())
+			}
 
 			grp.addSSHKeys(resp.Body)
 		}


### PR DESCRIPTION
… response from the google group/user APIs

The http client doesn't return an error for non-2xx responses, so you need to check the response matches an expected value.

Gives out errors like this now:
```
2019/05/29 13:59:59 Listening on :8080
2019/05/29 14:00:30 google - Error building user/group/key map: {
 "error": {
  "errors": [
   {
    "domain": "global",
    "reason": "forbidden",
    "message": "Not Authorized to access this resource/api"
   }
  ],
  "code": 403,
  "message": "Not Authorized to access this resource/api"
 }
}
```